### PR TITLE
fix AuthHelper::getUserEmail email validity check

### DIFF
--- a/roundcube/lib/AuthHelper.php
+++ b/roundcube/lib/AuthHelper.php
@@ -132,7 +132,7 @@ class AuthHelper
         }
 
         $email = \OC::$server->getUserSession()->getUser()->getEMailAddress();
-        if (strpos($email, '@') === true) {
+        if (strpos($email, '@') !== false) {
             return $email;
         }
 


### PR DESCRIPTION
As `strpos` returns a numerical value when the requested pattern has been found, `getUserEmail` in the current state of things will always return the owncloud username. According to #4, this isn't the intented behaviour. The following PR should fix that.