### PR TITLE
no longer sets Content-Length header in BackLogin

### DIFF
--- a/roundcube/lib/BackLogin.php
+++ b/roundcube/lib/BackLogin.php
@@ -180,7 +180,6 @@ class BackLogin
                         'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
                         'Accept-Encoding: identity',
                         'Content-Type: ' . self::FORM_URLENCODED,
-                        'Content-Length: ' . strlen($postData),
                         'Cache-Control: no-cache',
                         'Pragma: no-cache'
                     );


### PR DESCRIPTION
My attempts at opening the Roundcube application ended up as request timeouts. After looking up the issue, I stumbled upon this:

https://stackoverflow.com/questions/24779634/php-curl-timeout-in-redirections

I think we can assume that, for whatever reasons, `strlen($postData)` wasn't returning the proper value for Content-Length, resulting in Roundcube never responding to a request that didn't consist of as many bytes as expected.

The solution to this is actually pretty simple: if unspecified, php-curl will set the Content-Length header on its own. It's probably best not to interfere, and that's exactly the intent of this PR.